### PR TITLE
Updating Node.js version to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   push
 jobs:
   install:
-    runs-on: ubunto-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Install GH CLI
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: "CI"
+on:
+  push
+jobs:
+  install:
+    runs-on: ubunto-latest
+    steps:
+      - name: Install GH CLI
+        uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,0 @@
-name: "CI"
-on:
-  push
-jobs:
-  install:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install GH CLI
-        uses: ./

--- a/action.yml
+++ b/action.yml
@@ -7,5 +7,5 @@ inputs:
     required: false
     default: '2.14.2'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
Updating the node version to remove warning in the github workflow

The warning:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: dev-hanz-ops/install-gh-cli-action@0.0.2