### PR TITLE
Update readme with working example and update cli version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Selfhosted runners do not come with the GH CLI out of the box. This action is an
 - name: Install GH CLI
   uses: dev-hanz-ops/install-gh-cli-action@v0.1.0
   with:
-    gh-cli-version: 2.32.0
+    gh-cli-version: 2.32.0 # optional, see action.yml for current default
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Selfhosted runners do not come with the GH CLI out of the box. This action is an
 
 ```yaml
 - name: Install GH CLI
-  uses: dev-hanz-ops/install-gh-cli-action@0.1.0
+  uses: dev-hanz-ops/install-gh-cli-action@v0.1.0
   with:
     gh-cli-version: 2.32.0
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Selfhosted runners do not come with the GH CLI out of the box. This action is an
 
 ```yaml
 - name: Install GH CLI
-  uses: dev-hanz-ops/install-gh-cli-action
+  uses: dev-hanz-ops/install-gh-cli-action@0.1.0
   with:
-    gh-cli-version: 2.14.2 # optional, see action.yml for current default
+    gh-cli-version: 2.32.0
 ```


### PR DESCRIPTION
Currently, when used without a version, GitHub Action throws the following error.

Error:
Fix `uses` attribute must be a path, a Docker image, or owner/repo@ref error